### PR TITLE
 [STEP 09/10] 동시성 이슈 DB LOCK 적용 / 부가로직 구현

### DIFF
--- a/docs/concurrency/step09_resolve.md
+++ b/docs/concurrency/step09_resolve.md
@@ -1,0 +1,3 @@
+
+## 동시성 이슈 해결위한 DB LOCK 적용 
+[보고서링크](https://www.notion.so/DB-Lock-1dfabb7ee9508061bdedc1f92046404a?pvs=4)

--- a/src/main/java/kr/hhplus/be/server/domain/coupon/Coupon.java
+++ b/src/main/java/kr/hhplus/be/server/domain/coupon/Coupon.java
@@ -31,6 +31,15 @@ public class Coupon {
     @Column(nullable = false)
     private LocalDateTime expirationDate;
 
+    public Coupon(String couponNm, int discountRate, int issuedCount, int remainingCount, LocalDateTime issueDate, LocalDateTime expirationDate) {
+        this.couponNm = couponNm;
+        this.discountRate = discountRate;
+        this.issuedCount = issuedCount;
+        this.remainingCount = remainingCount;
+        this.issueDate = issueDate;
+        this.expirationDate = expirationDate;
+    }
+
     public boolean isExpired(LocalDateTime now) {
         return expirationDate.isBefore(now);
     }

--- a/src/main/java/kr/hhplus/be/server/domain/coupon/CouponRepository.java
+++ b/src/main/java/kr/hhplus/be/server/domain/coupon/CouponRepository.java
@@ -5,4 +5,5 @@ import java.util.Optional;
 public interface CouponRepository {
     Optional<Coupon> findById(int couponId);
     Coupon save(Coupon coupon);
+    Optional<Coupon> findByIdForUpdate(int couponId);
 }

--- a/src/main/java/kr/hhplus/be/server/domain/coupon/CouponService.java
+++ b/src/main/java/kr/hhplus/be/server/domain/coupon/CouponService.java
@@ -1,8 +1,8 @@
 package kr.hhplus.be.server.domain.coupon;
 
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 
@@ -24,9 +24,10 @@ public class CouponService {
                 ).orElse(null); // 아니라면 null 처리
     }
 
+    @Transactional
     public CouponInfo.issuedCoupon issueCoupon(CouponCommand.Issue command) {
 
-        Coupon coupon = couponRepository.findById(command.getCouponId())
+        Coupon coupon = couponRepository.findByIdForUpdate(command.getCouponId())
                 .orElseThrow(() -> new IllegalArgumentException("해당 쿠폰이 존재하지 않습니다."));
 
         // 쿠폰 유효성 및 재고 확인

--- a/src/main/java/kr/hhplus/be/server/domain/point/UserPoint.java
+++ b/src/main/java/kr/hhplus/be/server/domain/point/UserPoint.java
@@ -27,6 +27,10 @@ public class UserPoint {
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
+    @Version
+    private Long version;
+
+
     public UserPoint(int userId, int initialPoint) {
         this.userId = userId;
         this.point = initialPoint;

--- a/src/main/java/kr/hhplus/be/server/domain/point/UserPointRepository.java
+++ b/src/main/java/kr/hhplus/be/server/domain/point/UserPointRepository.java
@@ -5,6 +5,6 @@ import java.util.Optional;
 public interface UserPointRepository {
 
     Optional<UserPoint> findByUserId(int userId);
-    void save(UserPoint userPoint);
+    UserPoint save(UserPoint userPoint);
 
 }

--- a/src/main/java/kr/hhplus/be/server/domain/product/ProductOption.java
+++ b/src/main/java/kr/hhplus/be/server/domain/product/ProductOption.java
@@ -37,6 +37,14 @@ public class ProductOption {
         this.createdAt = LocalDateTime.now();
     }
 
+    public ProductOption(int productId, String optionNm, int price, int remaining) {
+        this.productId = productId;
+        this.optionNm = optionNm;
+        this.price = price;
+        this.remaining = remaining;
+        this.createdAt = LocalDateTime.now();
+    }
+
     public void decrease(int quantity) {
         if(quantity <=0) throw new IllegalArgumentException("수량은 0보다 커야합니다.");
         if (remaining < quantity) throw new IllegalStateException("재고가 부족합니다.");

--- a/src/main/java/kr/hhplus/be/server/domain/product/ProductOptionRepository.java
+++ b/src/main/java/kr/hhplus/be/server/domain/product/ProductOptionRepository.java
@@ -6,4 +6,6 @@ import java.util.Optional;
 public interface ProductOptionRepository {
     List<ProductOption> findByProductId(int productId);
     Optional<ProductOption> findById(int optionId);
+    Optional<ProductOption> findByIdForUpdate(int optionId);
+    ProductOption save(ProductOption option);
 }

--- a/src/main/java/kr/hhplus/be/server/domain/product/ProductService.java
+++ b/src/main/java/kr/hhplus/be/server/domain/product/ProductService.java
@@ -2,6 +2,7 @@ package kr.hhplus.be.server.domain.product;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -39,10 +40,11 @@ public class ProductService {
     /**
      * 재고차감 메소드
      * */
+    @Transactional
     public void decreaseProduct(List<ProductCommand.OrderOption> commands) {
 
         for (ProductCommand.OrderOption command : commands) {
-            ProductOption option = productOptionRepository.findById(command.getProductOptionId())
+            ProductOption option = productOptionRepository.findByIdForUpdate(command.getProductOptionId())
                     .orElseThrow(() -> new IllegalArgumentException("상품 옵션이 존재하지 않음"));
 
             option.decrease(command.getQuantity()); // 재고 차감

--- a/src/main/java/kr/hhplus/be/server/infrastructure/coupon/CouponJpaRepository.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/coupon/CouponJpaRepository.java
@@ -1,8 +1,19 @@
 package kr.hhplus.be.server.infrastructure.coupon;
 
+import jakarta.persistence.LockModeType;
 import kr.hhplus.be.server.domain.coupon.Coupon;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
+@Repository
 public interface CouponJpaRepository extends JpaRepository<Coupon, Integer> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT c FROM Coupon c WHERE c.couponId = :couponId")
+    Optional<Coupon> findByIdForUpdate(int couponId);
 
 }

--- a/src/main/java/kr/hhplus/be/server/infrastructure/coupon/CouponRepositoryImpl.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/coupon/CouponRepositoryImpl.java
@@ -22,4 +22,9 @@ public class CouponRepositoryImpl implements CouponRepository {
     public Coupon save(Coupon coupon) {
         return couponJpaRepository.save(coupon);
     }
+
+    public Optional<Coupon> findByIdForUpdate(int couponId) {
+        return couponJpaRepository.findByIdForUpdate(couponId);
+    }
+
 }

--- a/src/main/java/kr/hhplus/be/server/infrastructure/coupon/UserCouponRepositoryImpl.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/coupon/UserCouponRepositoryImpl.java
@@ -21,6 +21,5 @@ public class UserCouponRepositoryImpl implements UserCouponRepository {
     @Override
     public void save(UserCoupon userCoupon) {
         userCouponJpaRepository.save(userCoupon);
-
     }
 }

--- a/src/main/java/kr/hhplus/be/server/infrastructure/point/UserPointRepositoryImpl.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/point/UserPointRepositoryImpl.java
@@ -19,7 +19,7 @@ public class UserPointRepositoryImpl implements UserPointRepository {
     }
 
     @Override
-    public void save(UserPoint userPoint) {
-        userPointJpaRepository.save(userPoint);
+    public UserPoint save(UserPoint userPoint) {
+        return userPointJpaRepository.save(userPoint);
     }
 }

--- a/src/main/java/kr/hhplus/be/server/infrastructure/product/ProductOptionJpaRepository.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/product/ProductOptionJpaRepository.java
@@ -1,11 +1,18 @@
 package kr.hhplus.be.server.infrastructure.product;
 
+import jakarta.persistence.LockModeType;
 import kr.hhplus.be.server.domain.product.ProductOption;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ProductOptionJpaRepository extends JpaRepository<ProductOption, Integer> {
 
     List<ProductOption> findByProductId(int productId);
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT p FROM ProductOption p WHERE p.productOptionId = :productOptionId")
+    Optional<ProductOption> findByIdForUpdate(int productOptionId);
 }

--- a/src/main/java/kr/hhplus/be/server/infrastructure/product/ProductOptionRepositoryImpl.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/product/ProductOptionRepositoryImpl.java
@@ -24,4 +24,14 @@ public class ProductOptionRepositoryImpl implements ProductOptionRepository {
         return productOptionJpaRepository.findById(optionId);
     }
 
+    @Override
+    public Optional<ProductOption> findByIdForUpdate(int optionId) {
+        return productOptionJpaRepository.findByIdForUpdate(optionId);
+    }
+
+    @Override
+    public ProductOption save(ProductOption option) {
+        return productOptionJpaRepository.save(option);
+    }
+
 }

--- a/src/test/java/kr/hhplus/be/server/coupon/CouponConcurrencyTest.java
+++ b/src/test/java/kr/hhplus/be/server/coupon/CouponConcurrencyTest.java
@@ -9,9 +9,12 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 
 @SpringBootTest
@@ -32,16 +35,16 @@ class CouponConcurrencyTest {
     @BeforeEach
     void setUp() {
         // 테스트용 쿠폰 생성
-        Coupon coupon = new Coupon(1, "테스트 쿠폰", 20, 10, 10, LocalDateTime.now(), LocalDateTime.now().plusDays(1));
-        couponRepository.save(coupon);
-        couponId = coupon.getCouponId();
+        Coupon coupon = new Coupon("테스트 쿠폰", 20, 5, 5, LocalDateTime.now(), LocalDateTime.now().plusDays(1));
+        Coupon saveCoupon = couponRepository.save(coupon);
+        couponId = saveCoupon.getCouponId();
     }
 
     @Test
-    @DisplayName("선착순쿠폰 여러명 동시 발급 시도 - 동시성 테스트")
+    @DisplayName("선착순 쿠폰 여러명 동시 발급 시도 - 동시성 테스트")
     void givenAvailableCoupon_whenIssuingCouponAtTheSameTime_thenFailure() throws InterruptedException {
 
-        int threadCount = 10; // 10명이 동시에 발급 시도
+        int threadCount = 5; // 10명이 동시에 발급 시도
         ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
         CountDownLatch latch = new CountDownLatch(threadCount);
 
@@ -50,9 +53,9 @@ class CouponConcurrencyTest {
             executorService.submit(() -> {
                 try {
                     CouponCommand.Issue command = new CouponCommand.Issue(userId, couponId);
-                    couponService.issueCoupon(command);
+                    CouponInfo.issuedCoupon userCoupon = couponService.issueCoupon(command);
                 } catch (Exception e) {
-                    System.out.println("실패: " + e.getMessage());
+                     e.printStackTrace();
                 } finally {
                     latch.countDown();
                 }
@@ -62,8 +65,11 @@ class CouponConcurrencyTest {
         latch.await();
         executorService.shutdown(); // 스레드 풀 종료
 
-        // 실제로 발급된 쿠폰 수가 최대 재고 수보다 크지 않음을 확인
-//        long issuedCount = userCouponRepository.countByCouponId(couponId);
-//        assertThat(issuedCount).isLessThanOrEqualTo(5);
+        Optional<Coupon> issuedCoupon = couponRepository.findById(couponId);
+        if (issuedCoupon.isPresent()) {
+            int remainingCnt = issuedCoupon.get().getRemainingCount();
+            assertThat(remainingCnt).isEqualTo(0);
+        }
+
     }
 }

--- a/src/test/java/kr/hhplus/be/server/point/PointConcurrencyTest.java
+++ b/src/test/java/kr/hhplus/be/server/point/PointConcurrencyTest.java
@@ -1,0 +1,94 @@
+package kr.hhplus.be.server.point;
+
+
+import kr.hhplus.be.server.domain.point.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+@ActiveProfiles("test")
+@SpringBootTest
+public class PointConcurrencyTest {
+
+    @Autowired
+    private PointService pointService;
+
+    @Autowired
+    private UserPointRepository userPointRepository;
+
+    @Autowired
+    private UserPointHistRepository userPointHistRepository;
+
+    private int userId;
+
+
+    @BeforeEach
+    void setUp() {
+        UserPoint userPoint = new UserPoint(1, 0);
+        userPointRepository.save(userPoint);
+        userId = userPoint.getUserId();
+    }
+
+
+    @Test
+    @DisplayName("포인트 충전 따닥이슈일때 - 동시성 테스트") // 낙관적락
+    void givenAvailableCoupon_whenIssuingCouponAtTheSameTime_thenFailure() throws InterruptedException {
+
+        int threadCount = 5; // 따닥으로 5회 충전 시도
+        int chargePoint = 5000;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        AtomicInteger successCount = new AtomicInteger();
+
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    pointService.charge(new PointCommand.Charge(userId, chargePoint));
+                    successCount.incrementAndGet(); // 성공한 충전만 카운트
+                } catch (Exception e) {
+                    e.printStackTrace();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+        latch.await();
+        executorService.shutdown(); // 스레드 풀 종료
+
+        int resultPoint = successCount.get() * chargePoint;
+
+        Optional<UserPoint> userPoint = userPointRepository.findByUserId(1);
+        List<UserPointHist> userPointHists = userPointHistRepository.findByUserId(1);
+        int histTotalPoint = userPointHists.stream()
+                .mapToInt(hist -> {
+                    if (hist.getType() == PointHistoryType.CHARGE) {
+                        return hist.getPoint();
+                    } else if (hist.getType() == PointHistoryType.USE) {
+                        return -hist.getPoint();
+                    } else {
+                        return 0;
+                    }
+                })
+                .sum();
+
+        if(userPoint.isPresent()) {
+            int point = userPoint.get().getPoint();
+            assertThat(histTotalPoint).isEqualTo(point);
+            assertThat(point).isEqualTo(resultPoint);
+        }
+    }
+}

--- a/src/test/java/kr/hhplus/be/server/product/ProductConcurrencyTest.java
+++ b/src/test/java/kr/hhplus/be/server/product/ProductConcurrencyTest.java
@@ -1,0 +1,72 @@
+package kr.hhplus.be.server.product;
+
+import kr.hhplus.be.server.domain.product.ProductCommand;
+import kr.hhplus.be.server.domain.product.ProductOption;
+import kr.hhplus.be.server.domain.product.ProductOptionRepository;
+import kr.hhplus.be.server.domain.product.ProductService;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@SpringBootTest
+public class ProductConcurrencyTest {
+
+    @Autowired
+    private ProductService productService;
+
+    @Autowired
+    private ProductOptionRepository productOptionRepository;
+
+    private int testOptionId;
+
+    @BeforeEach
+    void setUp() {
+        // 초기 재고 세팅
+        ProductOption initialOption = new ProductOption(1,"아디다스 가젤", 3000, 5);
+        ProductOption productOption = productOptionRepository.save(initialOption);
+        testOptionId = productOption.getProductOptionId();
+    }
+
+    @Test
+    void testtest() throws InterruptedException {
+        int numberOfThreads = 5;
+        CountDownLatch latch = new CountDownLatch(numberOfThreads);
+        ExecutorService executor = Executors.newFixedThreadPool(numberOfThreads);
+
+        int decreaseAmount = 1;
+
+        for (int i = 0; i < numberOfThreads; i++) {
+            executor.submit(() -> {
+                try {
+                    ProductCommand.OrderOption command = new ProductCommand.OrderOption(testOptionId, decreaseAmount);
+                    productService.decreaseProduct(List.of(command));
+                } catch (Exception e) {
+                    e.printStackTrace();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        ProductOption option = productOptionRepository.findById(testOptionId)
+                .orElseThrow(() -> new IllegalStateException("상품 옵션이 존재하지 않음"));
+
+        executor.shutdown();
+
+        // 검증 로직
+        assertThat(option.getRemaining()).isEqualTo(0);
+    }
+}


### PR DESCRIPTION
##  [STEP 09/10] 동시성 이슈 DB LOCK 적용 / 부가로직 구현

## PR 설명

동시성이 문제가 된다고 판단한 기능을 추려서 동시성을 일으키고 이를 DB LOCK으로 해결했습니다. 
- 선착순 쿠폰제공
- 포인트 충전/사용
- 재고차감

### 🎞️ 작업내용
✔️ 선착순 쿠폰제공 동시성 이슈 확인 및 해결 [6a2d7b4](https://github.com/OO-b/E-commerce-system/commit/6a2d7b42256ed13fb3565b54b28ab9ce05911035)
✔️ 포인트 충전 / 사용 동시성 이슈 확인 및 해결 [17da18d](https://github.com/OO-b/E-commerce-system/commit/17da18dd11d01dc5defd45135cf99f5f225c898b) [fd4ff58](https://github.com/OO-b/E-commerce-system/commit/fd4ff58ee533dfb7542fe9a3ce00e0db1f678295)
✔️ 재고차감 동시성 이슈 확인 및 해결 [a4a5540](https://github.com/OO-b/E-commerce-system/commit/a4a5540d764cb43dd0b2a9414b2ef28c1e33b8ca)
✔️ 동시성 이슈 해결을 위한 DB락 적용 보고서 작성 [f14750c](https://github.com/OO-b/E-commerce-system/commit/f14750cb3a6c7d9074326bd41d1eb2d61f391686)


## 리뷰 포인트


1. 이번 동시성 이슈 및 해결 진행시에는 전체적으로 domain layer에서 진행하였는데 제 코드는 주문/결제가 동시에 있는 로직이여서 OrderFacade도 필요하다고 생각이 들었습니다. 이런경우라면 Facade도 하는게 맞을까요? (사실 주문 facade 부분 제 코드가 아..주 마음에 안듭니다만) 
- 이번 범위가 아니긴 하지만, orderFacade에 주문 로직을 아직 리팩토링 하지 못해 계속 신경이 쓰입니다..
주문과 결제를 하나로 묶어서 진행하는게 맞을지에 대한 고민도 있고, 해당 파사드에는 흐름이 아니라 로직도 존재한다고 생각이 드는데 어떻게 수정해야 할지 아직 손을 대지 못하고 있습니다. 혹시 이 부분을 보시고 수정해야 할 방향이나 방법을 말씀해주실 수 있으실까요🥲 [OrderFacade](https://github.com/OO-b/E-commerce-system/blob/main/src/main/java/kr/hhplus/be/server/application/order/OrderFacade.java) 

2. 이번에 부가로직을 구현하지 못했지만, 만약 filter나 interceptor를 구현했다면 E2E 테스트로 진행하면 되는걸까요?
    mockMvc를 사용하는경우 controller부터 확인이 가능한 것으로 알고있는데 filter나 interceptor를 적용 후 확인하려고 한다면 
   TestRestTemplate을 사용하시는지? 아니면 어떤방식으로 사용하시는지 궁금합니다.

## Definition of Done (DoD)

- [x] 동시성 이슈 해결해야하는 로직 확인 및 DB락으로 해결
- [x] 해결방법 보고서 작성
- [ ] 부가기능 로직 구현
